### PR TITLE
Remove exports.qbx_core: from GetClosestPlayer

### DIFF
--- a/client/interactions.lua
+++ b/client/interactions.lua
@@ -148,7 +148,7 @@ local function isTooFar(player, distance, maxDistance)
 end
 
 RegisterNetEvent('police:client:SearchPlayer', function()
-    local player, distance = exports.qbx_core:GetClosestPlayer()
+    local player, distance = GetClosestPlayer()
     if isTooFar(player, distance) then return end
     local playerId = GetPlayerServerId(player)
     exports.ox_inventory:openNearbyInventory()
@@ -156,14 +156,14 @@ RegisterNetEvent('police:client:SearchPlayer', function()
 end)
 
 RegisterNetEvent('police:client:SeizeCash', function()
-    local player, distance = exports.qbx_core:GetClosestPlayer()
+    local player, distance = GetClosestPlayer()
     if isTooFar(player, distance) then return end
     local playerId = GetPlayerServerId(player)
     TriggerServerEvent("police:server:SeizeCash", playerId)
 end)
 
 RegisterNetEvent('police:client:RobPlayer', function()
-    local player, distance = exports.qbx_core:GetClosestPlayer()
+    local player, distance = GetClosestPlayer()
     if isTooFar(player, distance) then return end
     local playerPed = GetPlayerPed(player)
     local playerId = GetPlayerServerId(player)
@@ -206,7 +206,7 @@ RegisterNetEvent('police:client:RobPlayer', function()
 end)
 
 RegisterNetEvent('police:client:JailPlayer', function()
-    local player, distance = exports.qbx_core:GetClosestPlayer()
+    local player, distance = GetClosestPlayer()
     if isTooFar(player, distance) then return end
     local playerId = GetPlayerServerId(player)
     local dialog = lib.inputDialog(Lang:t('info.jail_time_input'), {
@@ -220,7 +220,7 @@ RegisterNetEvent('police:client:JailPlayer', function()
 end)
 
 RegisterNetEvent('police:client:BillPlayer', function()
-    local player, distance = exports.qbx_core:GetClosestPlayer()
+    local player, distance = GetClosestPlayer()
     if isTooFar(player, distance) then return end
     local playerId = GetPlayerServerId(player)
     local dialog = lib.inputDialog(Lang:t('info.bill'), {
@@ -234,7 +234,7 @@ RegisterNetEvent('police:client:BillPlayer', function()
 end)
 
 local function triggerIfHandsFree(eventName)
-    local player, distance = exports.qbx_core:GetClosestPlayer()
+    local player, distance = GetClosestPlayer()
     if isTooFar(player, distance) then return end
     local playerId = GetPlayerServerId(player)
     if QBX.PlayerData.metadata.ishandcuffed or isEscorted then return end
@@ -254,7 +254,7 @@ RegisterNetEvent('police:client:EscortPlayer', function()
 end)
 
 RegisterNetEvent('police:client:KidnapPlayer', function()
-    local player, distance = exports.qbx_core:GetClosestPlayer()
+    local player, distance = GetClosestPlayer()
     if isTooFar(player, distance) then return end
     local playerId = GetPlayerServerId(player)
     if IsPedInAnyVehicle(GetPlayerPed(player), false) or QBX.PlayerData.metadata.ishandcuffed or isEscorted then return end
@@ -263,7 +263,7 @@ end)
 
 RegisterNetEvent('police:client:CuffPlayerSoft', function()
     if IsPedRagdoll(cache.ped) then return end
-    local player, distance = exports.qbx_core:GetClosestPlayer()
+    local player, distance = GetClosestPlayer()
     if isTooFar(player, distance, 1.5) then return end
     local playerId = GetPlayerServerId(player)
     if IsPedInAnyVehicle(GetPlayerPed(player), false) or cache.vehicle then
@@ -277,7 +277,7 @@ end)
 RegisterNetEvent('police:client:CuffPlayer', function()
     if IsPedRagdoll(cache.ped) then return end
 
-    local player, distance = exports.qbx_core:GetClosestPlayer()
+    local player, distance = GetClosestPlayer()
     if isTooFar(player, distance) then return end
     if exports.ox_inventory:Search('count', Config.HandCuffItem) == 0 then
         exports.qbx_core:Notify(Lang:t("error.no_cuff"), 'error')


### PR DESCRIPTION
## Description

According with qbx documentation, the function GetClosestPlayer should be called without the export, it is part of the Module: utils
ref. https://qbox-project.github.io/resources/core/functions/client#getclosestplayer

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
