### PR TITLE
:bug: Fix isPlayerDead callback

### DIFF
--- a/client/interactions.lua
+++ b/client/interactions.lua
@@ -315,7 +315,7 @@ RegisterNetEvent('police:client:DeEscort', function()
 end)
 
 RegisterNetEvent('police:client:GetKidnappedTarget', function(playerId)
-    if QBX.PlayerData.metadata.idead or QBX.PlayerData.metadata.inlaststand or QBX.PlayerData.metadata.ishandcuffed then
+    if QBX.PlayerData.metadata.isdead or QBX.PlayerData.metadata.inlaststand or QBX.PlayerData.metadata.ishandcuffed then
         if not isEscorted then
             isEscorted = true
             local dragger = GetPlayerPed(GetPlayerFromServerId(playerId))

--- a/server/main.lua
+++ b/server/main.lua
@@ -76,7 +76,7 @@ end)
 -- Callbacks
 lib.callback.register('police:server:isPlayerDead', function(_, playerId)
     local player = exports.qbx_core:GetPlayer(playerId)
-    return player.PlayerData.metadata.idead
+    return player.PlayerData.metadata.isdead
 end)
 
 lib.callback.register('police:GetPlayerStatus', function(_, playerId)


### PR DESCRIPTION
PlayerData.metadata.idead should be PlayerData.metadata.isdead to properly allow for players to be robbed while dead.

## Description

Currently you are unable to rob a dead player. This is due to the callback returning metadata that doesn't exist in the core. This change returns the correct metadata information.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
