### PR TITLE
:bug: Robbing players fix

### DIFF
--- a/client/interactions.lua
+++ b/client/interactions.lua
@@ -195,7 +195,7 @@ RegisterNetEvent('police:client:RobPlayer', function()
         if #(pos - plyCoords) < 2.5 then
             StopAnimTask(cache.ped, 'random@shop_robbery', 'robbery_action_b', 1.0)
             exports.ox_inventory:openNearbyInventory()
-            TriggerServerEvent('inventory:server:RobPlayer', playerId)
+            TriggerServerEvent('police:server:RobPlayer', playerId)
         else
             exports.qbx_core:Notify(Lang:t('error.none_nearby'), 'error')
         end


### PR DESCRIPTION
Robbing players would display the inventory of the robbed player but not remove the cash and notify the player they were being robbed. This was due to a call to a nonexistent event.

## Description

Fixes removing cash from robbed players and giving it to the robber.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
