### PR TITLE
Fix uncuff animation bug

### DIFF
--- a/client/interactions.lua
+++ b/client/interactions.lua
@@ -357,7 +357,7 @@ RegisterNetEvent('police:client:GetCuffed', function(playerId, isSoftcuff)
             cuffType = 16
             exports.qbx_core:Notify(Lang:t('info.cuff'), 'success')
         else
-            cuffType = 49
+            cuffType = 48
             exports.qbx_core:Notify(Lang:t('info.cuffed_walk'), 'success')
         end
         getCuffedAnimation(playerId)


### PR DESCRIPTION
Wrong flag used for soft cuff breaks the animation when you are uncuffed until you cancel the emote

Fixes #66

## Description

It changes cuffType from 49 to 48 and addresses the issue where the player appears cuffed after being uncuffed. Fixes #66 

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
