### PR TITLE
fix: remove stash and evidence

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -482,48 +482,6 @@ else
 end
 
 CreateThread(function()
-    -- Evidence Storage
-    for _, v in pairs(sharedConfig.locations.evidence) do
-        lib.zones.box({
-            coords = v,
-            size = vec3(2, 2, 2),
-            rotation = 0.0,
-            debug = config.polyDebug,
-            onEnter = function()
-                if QBX.PlayerData.job.type == 'leo' and QBX.PlayerData.job.onduty then
-                    inPrompt = true
-                    lib.showTextUI(Lang:t('info.evidence'))
-                    uiPrompt('evidence')
-                end
-            end,
-            onExit = function()
-                lib.hideTextUI()
-                inPrompt = false
-            end
-        })
-    end
-
-    -- Personal Stash
-    for _, v in pairs(sharedConfig.locations.stash) do
-        lib.zones.box({
-            coords = v,
-            size = vec3(2, 2, 2),
-            rotation = 0.0,
-            debug = config.polyDebug,
-            onEnter = function()
-                inStash = true
-                inPrompt = true
-                lib.showTextUI(Lang:t('info.stash_enter'))
-                uiPrompt('stash')
-            end,
-            onExit = function()
-                lib.hideTextUI()
-                inPrompt = false
-                inStash = false
-            end
-        })
-    end
-
     -- Police Trash
     for i = 1, #sharedConfig.locations.trash do
         local v = sharedConfig.locations.trash[i]


### PR DESCRIPTION
## Description

Evidence and stashes are configured in ox_inventory. This code points to empty config values that generate an error on start. Removing this code fixes that

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ ] My pull request fits the contribution guidelines & code conventions.
