### PR TITLE
fix: distance checks

### DIFF
--- a/client/interactions.lua
+++ b/client/interactions.lua
@@ -134,42 +134,38 @@ RegisterNetEvent('police:client:PutInVehicle', function()
     end
 end)
 
----@param player number
----@param distance number
----@param maxDistance? number
----@return boolean
-local function isTooFar(player, distance, maxDistance)
-    if not player or distance >= (maxDistance or 2.5) then
+---Check for closest player within distance or 2.5 units
+---@param distance number?
+---@return number? playerId
+---@return number? playerPed
+local function getClosestPlayer(distance)
+    local coords = GetEntityCoords(cache.ped)
+    local player, playerPed = lib.getClosestPlayer(coords, (distance or 2.5))
+    if not player then
         exports.qbx_core:Notify(Lang:t('error.none_nearby'), 'error')
-        return true
+        return
     end
-    return false
+    return player, playerPed
 end
 
 RegisterNetEvent('police:client:SearchPlayer', function()
-    local coords = GetEntityCoords(cache.ped)
-    local player, _, playerCoords = lib.getClosestPlayer(coords)
-    local distance = #(coords - playerCoords)
-    if isTooFar(coords, distance) then return end
+    local player = getClosestPlayer()
+    if not player then return end
     local playerId = GetPlayerServerId(player)
     exports.ox_inventory:openNearbyInventory()
     TriggerServerEvent('police:server:SearchPlayer', playerId)
 end)
 
 RegisterNetEvent('police:client:SeizeCash', function()
-    local coords = GetEntityCoords(cache.ped)
-    local player, _, playerCoords = lib.getClosestPlayer(coords)
-    local distance = #(coords - playerCoords)
-    if isTooFar(coords, distance) then return end
+    local player = getClosestPlayer()
+    if not player then return end
     local playerId = GetPlayerServerId(player)
     TriggerServerEvent('police:server:SeizeCash', playerId)
 end)
 
 RegisterNetEvent('police:client:RobPlayer', function()
-    local coords = GetEntityCoords(cache.ped)
-    local player, playerPed, playerCoords = lib.getClosestPlayer(coords)
-    local distance = #(coords - playerCoords)
-    if isTooFar(coords, distance) then return end
+    local player, playerPed  = getClosestPlayer()
+    if not player then return end
     local playerId = GetPlayerServerId(player)
     if not (IsEntityPlayingAnim(playerPed, 'missminuteman_1ig_2', 'handsup_base', 3) or IsEntityPlayingAnim(playerPed, 'mp_arresting', 'idle', 3) or isTargetDead(playerId)) then
         exports.qbx_core:Notify(Lang:t('error.no_rob'), 'error')
@@ -210,10 +206,8 @@ RegisterNetEvent('police:client:RobPlayer', function()
 end)
 
 RegisterNetEvent('police:client:JailPlayer', function()
-    local coords = GetEntityCoords(cache.ped)
-    local player, _, playerCoords = lib.getClosestPlayer(coords)
-    local distance = #(coords - playerCoords)
-    if isTooFar(coords, distance) then return end
+    local player = getClosestPlayer()
+    if not player then return end
     local playerId = GetPlayerServerId(player)
     local dialog = lib.inputDialog(Lang:t('info.jail_time_input'), {
         {type = 'number', label = Lang:t('info.time_months'), min = 0}
@@ -226,10 +220,8 @@ RegisterNetEvent('police:client:JailPlayer', function()
 end)
 
 RegisterNetEvent('police:client:BillPlayer', function()
-    local coords = GetEntityCoords(cache.ped)
-    local player, _, playerCoords = lib.getClosestPlayer(coords)
-    local distance = #(coords - playerCoords)
-    if isTooFar(coords, distance) then return end
+    local player = getClosestPlayer()
+    if not player then return end
     local playerId = GetPlayerServerId(player)
     local dialog = lib.inputDialog(Lang:t('info.bill'), {
         {type = 'number', label = Lang:t('info.amount'), min = 0}
@@ -242,10 +234,8 @@ RegisterNetEvent('police:client:BillPlayer', function()
 end)
 
 local function triggerIfHandsFree(eventName)
-    local coords = GetEntityCoords(cache.ped)
-    local player, _, playerCoords = lib.getClosestPlayer(coords)
-    local distance = #(coords - playerCoords)
-    if isTooFar(coords, distance) then return end
+    local player = getClosestPlayer()
+    if not player then return end
     local playerId = GetPlayerServerId(player)
     if QBX.PlayerData.metadata.ishandcuffed or isEscorted then return end
     TriggerServerEvent(eventName, playerId)
@@ -264,10 +254,8 @@ RegisterNetEvent('police:client:EscortPlayer', function()
 end)
 
 RegisterNetEvent('police:client:KidnapPlayer', function()
-    local coords = GetEntityCoords(cache.ped)
-    local player, _, playerCoords = lib.getClosestPlayer(coords)
-    local distance = #(coords - playerCoords)
-    if isTooFar(coords, distance) then return end
+    local player = getClosestPlayer()
+    if not player then return end
     local playerId = GetPlayerServerId(player)
     if IsPedInAnyVehicle(GetPlayerPed(player), false) or QBX.PlayerData.metadata.ishandcuffed or isEscorted then return end
     TriggerServerEvent('police:server:KidnapPlayer', playerId)
@@ -275,10 +263,8 @@ end)
 
 RegisterNetEvent('police:client:CuffPlayerSoft', function()
     if IsPedRagdoll(cache.ped) then return end
-    local coords = GetEntityCoords(cache.ped)
-    local player, _, playerCoords = lib.getClosestPlayer(coords)
-    local distance = #(coords - playerCoords)
-    if isTooFar(coords, distance, 1.5) then return end
+    local player = getClosestPlayer(1.5)
+    if not player then return end
     local playerId = GetPlayerServerId(player)
     if IsPedInAnyVehicle(GetPlayerPed(player), false) or cache.vehicle then
         exports.qbx_core:Notify(Lang:t('error.vehicle_cuff'), 'error')
@@ -290,10 +276,8 @@ end)
 
 RegisterNetEvent('police:client:CuffPlayer', function()
     if IsPedRagdoll(cache.ped) then return end
-    local coords = GetEntityCoords(cache.ped)
-    local player, _, playerCoords = lib.getClosestPlayer(coords)
-    local distance = #(coords - playerCoords)
-    if isTooFar(coords, distance) then return end
+    local player = getClosestPlayer()
+    if not player then return end
     if exports.ox_inventory:Search('count', config.handcuffItems) == 0 then
         exports.qbx_core:Notify(Lang:t('error.no_cuff'), 'error')
         return

--- a/client/interactions.lua
+++ b/client/interactions.lua
@@ -148,8 +148,9 @@ end
 
 RegisterNetEvent('police:client:SearchPlayer', function()
     local coords = GetEntityCoords(cache.ped)
-    local player, _, distance = lib.getClosestPlayer(coords)
-    if isTooFar(player, distance) then return end
+    local player, _, playerCoords = lib.getClosestPlayer(coords)
+    local distance = #(coords - playerCoords)
+    if isTooFar(coords, distance) then return end
     local playerId = GetPlayerServerId(player)
     exports.ox_inventory:openNearbyInventory()
     TriggerServerEvent('police:server:SearchPlayer', playerId)
@@ -157,16 +158,18 @@ end)
 
 RegisterNetEvent('police:client:SeizeCash', function()
     local coords = GetEntityCoords(cache.ped)
-    local player, _, distance = lib.getClosestPlayer(coords)
-    if isTooFar(player, distance) then return end
+    local player, _, playerCoords = lib.getClosestPlayer(coords)
+    local distance = #(coords - playerCoords)
+    if isTooFar(coords, distance) then return end
     local playerId = GetPlayerServerId(player)
     TriggerServerEvent('police:server:SeizeCash', playerId)
 end)
 
 RegisterNetEvent('police:client:RobPlayer', function()
     local coords = GetEntityCoords(cache.ped)
-    local player, playerPed, distance = lib.getClosestPlayer(coords)
-    if isTooFar(player, distance) then return end
+    local player, playerPed, playerCoords = lib.getClosestPlayer(coords)
+    local distance = #(coords - playerCoords)
+    if isTooFar(coords, distance) then return end
     local playerId = GetPlayerServerId(player)
     if not (IsEntityPlayingAnim(playerPed, 'missminuteman_1ig_2', 'handsup_base', 3) or IsEntityPlayingAnim(playerPed, 'mp_arresting', 'idle', 3) or isTargetDead(playerId)) then
         exports.qbx_core:Notify(Lang:t('error.no_rob'), 'error')
@@ -208,8 +211,9 @@ end)
 
 RegisterNetEvent('police:client:JailPlayer', function()
     local coords = GetEntityCoords(cache.ped)
-    local player, _, distance = lib.getClosestPlayer(coords)
-    if isTooFar(player, distance) then return end
+    local player, _, playerCoords = lib.getClosestPlayer(coords)
+    local distance = #(coords - playerCoords)
+    if isTooFar(coords, distance) then return end
     local playerId = GetPlayerServerId(player)
     local dialog = lib.inputDialog(Lang:t('info.jail_time_input'), {
         {type = 'number', label = Lang:t('info.time_months'), min = 0}
@@ -223,8 +227,9 @@ end)
 
 RegisterNetEvent('police:client:BillPlayer', function()
     local coords = GetEntityCoords(cache.ped)
-    local player, _, distance = lib.getClosestPlayer(coords)
-    if isTooFar(player, distance) then return end
+    local player, _, playerCoords = lib.getClosestPlayer(coords)
+    local distance = #(coords - playerCoords)
+    if isTooFar(coords, distance) then return end
     local playerId = GetPlayerServerId(player)
     local dialog = lib.inputDialog(Lang:t('info.bill'), {
         {type = 'number', label = Lang:t('info.amount'), min = 0}
@@ -238,8 +243,9 @@ end)
 
 local function triggerIfHandsFree(eventName)
     local coords = GetEntityCoords(cache.ped)
-    local player, _, distance = lib.getClosestPlayer(coords)
-    if isTooFar(player, distance) then return end
+    local player, _, playerCoords = lib.getClosestPlayer(coords)
+    local distance = #(coords - playerCoords)
+    if isTooFar(coords, distance) then return end
     local playerId = GetPlayerServerId(player)
     if QBX.PlayerData.metadata.ishandcuffed or isEscorted then return end
     TriggerServerEvent(eventName, playerId)
@@ -259,8 +265,9 @@ end)
 
 RegisterNetEvent('police:client:KidnapPlayer', function()
     local coords = GetEntityCoords(cache.ped)
-    local player, _, distance = lib.getClosestPlayer(coords)
-    if isTooFar(player, distance) then return end
+    local player, _, playerCoords = lib.getClosestPlayer(coords)
+    local distance = #(coords - playerCoords)
+    if isTooFar(coords, distance) then return end
     local playerId = GetPlayerServerId(player)
     if IsPedInAnyVehicle(GetPlayerPed(player), false) or QBX.PlayerData.metadata.ishandcuffed or isEscorted then return end
     TriggerServerEvent('police:server:KidnapPlayer', playerId)
@@ -269,8 +276,9 @@ end)
 RegisterNetEvent('police:client:CuffPlayerSoft', function()
     if IsPedRagdoll(cache.ped) then return end
     local coords = GetEntityCoords(cache.ped)
-    local player, _, distance = lib.getClosestPlayer(coords)
-    if isTooFar(player, distance, 1.5) then return end
+    local player, _, playerCoords = lib.getClosestPlayer(coords)
+    local distance = #(coords - playerCoords)
+    if isTooFar(coords, distance, 1.5) then return end
     local playerId = GetPlayerServerId(player)
     if IsPedInAnyVehicle(GetPlayerPed(player), false) or cache.vehicle then
         exports.qbx_core:Notify(Lang:t('error.vehicle_cuff'), 'error')
@@ -283,8 +291,9 @@ end)
 RegisterNetEvent('police:client:CuffPlayer', function()
     if IsPedRagdoll(cache.ped) then return end
     local coords = GetEntityCoords(cache.ped)
-    local player, _, distance = lib.getClosestPlayer(coords)
-    if isTooFar(player, distance) then return end
+    local player, _, playerCoords = lib.getClosestPlayer(coords)
+    local distance = #(coords - playerCoords)
+    if isTooFar(coords, distance) then return end
     if exports.ox_inventory:Search('count', config.handcuffItems) == 0 then
         exports.qbx_core:Notify(Lang:t('error.no_cuff'), 'error')
         return


### PR DESCRIPTION
## Description

lib.getClosestPlayer returns playerId, playerPed, and playerCoords. Previous utils function automagically returned a distance value. This fixes that issue.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
