### PR TITLE
fix(heli): entity detection in getVehicleInView function

### DIFF
--- a/client/heli.lua
+++ b/client/heli.lua
@@ -107,7 +107,7 @@ local function getVehicleInView(cam)
     --DrawLine(coords, coords + (forward_vector * 100.0), 255, 0, 0, 255) -- debug line to show LOS of cam
     local rayHandle = CastRayPointToPoint(coords, coords + (forwardVector * 400.0), 10, cache.vehicle, 0)
     local _, _, _, _, entityHit = GetRaycastResult(rayHandle)
-    return IsEntityAVehicle(entityHit) and entityHit or 0
+    return entityHit > 0 and IsEntityAVehicle(entityHit) or 0
 end
 
 local function renderVehicleInfo(vehicle)


### PR DESCRIPTION
## Description

The fix ensures `entityHit` is a positive value before calling `IsEntityAVehicle()`, otherwise it creates a fatal error that forces the player to F8 quit to escape the heli cam.
![image](https://github.com/Qbox-project/qbx_policejob/assets/58707473/5b025121-ee02-4c70-ab1a-9d38c77413bf)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
