### PR TITLE
fix(server/main): dropping for attempted abuse

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -174,7 +174,7 @@ RegisterNetEvent('police:server:TakeOutImpound', function(plate, garage)
     local playerPed = GetPlayerPed(src)
     local playerCoords = GetEntityCoords(playerPed)
     local targetCoords = sharedConfig.locations.impound[garage]
-    if #(playerCoords - targetCoords) > 10.0 then return DropPlayer(src, 'Attempted exploit abuse') end
+    if #(playerCoords - targetCoords) > 10.0 then return end
 
     Unimpound(plate)
     exports.qbx_core:Notify(src, Lang:t('success.impound_vehicle_removed'), 'success')
@@ -186,7 +186,6 @@ local function isTargetTooFar(src, targetId, maxDistance)
     local playerCoords = GetEntityCoords(playerPed)
     local targetCoords = GetEntityCoords(targetPed)
     if #(playerCoords - targetCoords) > maxDistance then
-        DropPlayer(src, 'Attempted exploit abuse')
         return true
     end
     return false


### PR DESCRIPTION
## Description

Removes the code which drops a player for being too far away from someone.

- Should fix #97 _(there might be other issues that cause escorting to be broken, this just stops dropping players)_

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ ] My pull request fits the contribution guidelines & code conventions.
