### PR TITLE
fix(client/heli): vector expansion fix

### DIFF
--- a/client/heli.lua
+++ b/client/heli.lua
@@ -103,9 +103,9 @@ end
 
 local function getVehicleInView(cam)
     local coords = GetCamCoord(cam)
-    local forwardVector = rotAnglesToVec(GetCamRot(cam, 2))
+    local forwardVector = coords + (rotAnglesToVec(GetCamRot(cam, 2)) * 400.0)
     --DrawLine(coords, coords + (forward_vector * 100.0), 255, 0, 0, 255) -- debug line to show LOS of cam
-    local rayHandle = CastRayPointToPoint(coords, coords + (forwardVector * 400.0), 10, cache.vehicle, 0)
+    local rayHandle = CastRayPointToPoint(coords.x, coords.y, coords.z, forwardVector.x, forwardVector.y, forwardVector.z, 10, cache.vehicle, 0)
     local _, _, _, _, entityHit = GetRaycastResult(rayHandle)
     return entityHit > 0 and IsEntityAVehicle(entityHit) or 0
 end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
When using `use_experimental_fxv2_oal 'yes'` vector expansion for natives is not supported. This causes the native to bug the resource. This fixes that issue by explicitly defining the vectors for the native.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
