### PR TITLE
fix(client/heli): return entity not boolean

### DIFF
--- a/client/heli.lua
+++ b/client/heli.lua
@@ -107,7 +107,7 @@ local function getVehicleInView(cam)
     --DrawLine(coords, coords + (forward_vector * 100.0), 255, 0, 0, 255) -- debug line to show LOS of cam
     local rayHandle = CastRayPointToPoint(coords.x, coords.y, coords.z, forwardVector.x, forwardVector.y, forwardVector.z, 10, cache.vehicle, 0)
     local _, _, _, _, entityHit = GetRaycastResult(rayHandle)
-    return entityHit > 0 and IsEntityAVehicle(entityHit) or 0
+    return (entityHit > 0 and IsEntityAVehicle(entityHit)) and entityHit or 0
 end
 
 local function renderVehicleInfo(vehicle)


### PR DESCRIPTION
Fixes freezing cam issue

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Booleans are not entities.....

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
