### PR TITLE
fix(client/heli): set vehicleDetected

### DIFF
--- a/client/heli.lua
+++ b/client/heli.lua
@@ -107,7 +107,7 @@ local function getVehicleInView(cam)
     --DrawLine(coords, coords + (forward_vector * 100.0), 255, 0, 0, 255) -- debug line to show LOS of cam
     local rayHandle = CastRayPointToPoint(coords.x, coords.y, coords.z, forwardVector.x, forwardVector.y, forwardVector.z, 10, cache.vehicle, 0)
     local _, _, _, _, entityHit = GetRaycastResult(rayHandle)
-    return (entityHit > 0 and IsEntityAVehicle(entityHit)) and entityHit or 0
+    return entityHit <= 0 and nil or IsEntityAVehicle(entityHit) and entityHit
 end
 
 local function renderVehicleInfo(vehicle)
@@ -262,7 +262,8 @@ local function handleInVehicle()
             else
                 zoomValue = (1.0 / (FOV_MAX - FOV_MIN)) * (fov - FOV_MIN)
                 checkInputRotation(cam, zoomValue)
-                vehicleLockState = DoesEntityExist(getVehicleInView(cam)) and VEHICLE_LOCK_STATE.scanning or VEHICLE_LOCK_STATE.dormant
+                vehicleDetected = getVehicleInView(cam)
+                vehicleLockState = DoesEntityExist(vehicleDetected) and VEHICLE_LOCK_STATE.scanning or VEHICLE_LOCK_STATE.dormant
             end
             handleZoom(cam)
             hideHudThisFrame()


### PR DESCRIPTION
Somewhere in the conversion from qbus spaghet to qbox the variable to set the locked vehicle got lost. Tested and cam locks and unlocks as designed

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Without setting the vehicleDetected to anything the cam never locks. This fixes that issue and allows the cam to lock as intended enabling police to do police like things.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
