### PR TITLE
fix(server/main): use qbx_prison exports if present

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -166,7 +166,11 @@ lib.addCommand('unjail', {
     }
 }, function(source, args)
     if not checkLeoAndOnDuty(source) then return end
-    TriggerClientEvent('prison:client:UnjailPerson', args.id)
+    if GetResourceState('qbx_prison') == 'started' then
+        exports.qbx_prison:ReleasePlayer(args.id)
+    else
+        TriggerClientEvent('prison:client:UnjailPerson', args.id)
+    end
 end)
 
 lib.addCommand('clearblood', {help = Lang:t('commands.clearblood')}, function(source)

--- a/server/main.lua
+++ b/server/main.lua
@@ -292,7 +292,11 @@ RegisterNetEvent('police:server:JailPlayer', function(playerId, time)
         hasRecord = true,
         date = currentDate
     })
-    TriggerClientEvent('police:client:SendToJail', otherPlayer.PlayerData.source, time)
+    if GetResourceState('qbx_prison') == 'started' then
+        exports.qbx_prison:JailPlayer(otherPlayer.PlayerData.source, time)
+    else
+        TriggerClientEvent('police:client:SendToJail', otherPlayer.PlayerData.source, time)
+    end
     exports.qbx_core:Notify(src, Lang:t('info.sent_jail_for', {time = time}), 'inform')
 end)
 


### PR DESCRIPTION
If using qbx_prison then we should use the exports otherwise trigger the legacy event for backwards compatability

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Fixes inability to jail players if using qbx_prison. Maintains backwards compatibility with other resources looking for the event trigger.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
