### PR TITLE
refactor(server/main): only load compat if req

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -1,5 +1,4 @@
 local sharedConfig = require 'config.shared'
-local QBCore = exports['qb-core']:GetCoreObject()
 Plates = {}
 local playerStatus = {}
 local casings = {}
@@ -111,11 +110,6 @@ local function isPlateFlagged(plate)
     return Plates and Plates[plate] and Plates[plate].isflagged
 end
 
----@deprecated use qbx_police:server:isPlateFlagged
-QBCore.Functions.CreateCallback('police:IsPlateFlagged', function(_, cb, plate)
-    lib.print.warn(GetInvokingResource(), 'invoked deprecated callback police:IsPlateFlagged. Use qbx_police:server:isPlateFlagged instead.')
-    cb(isPlateFlagged(plate))
-end)
 
 lib.callback.register('qbx_police:server:isPlateFlagged', function(_, plate)
     return isPlateFlagged(plate)
@@ -131,13 +125,22 @@ local function isPoliceForcePresent()
     return false
 end
 
----@deprecated
-QBCore.Functions.CreateCallback('police:server:IsPoliceForcePresent', function(_, cb)
-    lib.print.warn(GetInvokingResource(), 'invoked deprecated callback police:server:IsPoliceForcePresent. Use lib callback qbx_police:server:isPoliceForcePresent instead')
-    cb(isPoliceForcePresent())
-end)
-
 lib.callback.register('qbx_police:server:isPoliceForcePresent', isPoliceForcePresent)
+
+if GetConvar('qbx:enablebridge', 'true') == 'true' then
+    local QBCore = exports['qb-core']:GetCoreObject()
+    ---@deprecated use qbx_police:server:isPlateFlagged
+    QBCore.Functions.CreateCallback('police:IsPlateFlagged', function(_, cb, plate)
+        lib.print.warn(GetInvokingResource(), 'invoked deprecated callback police:IsPlateFlagged. Use qbx_police:server:isPlateFlagged instead.')
+        cb(isPlateFlagged(plate))
+    end)
+
+    ---@deprecated
+    QBCore.Functions.CreateCallback('police:server:IsPoliceForcePresent', function(_, cb)
+        lib.print.warn(GetInvokingResource(), 'invoked deprecated callback police:server:IsPoliceForcePresent. Use lib callback qbx_police:server:isPoliceForcePresent instead')
+        cb(isPoliceForcePresent())
+    end)
+end
 
 -- Events
 RegisterNetEvent('police:server:Radar', function(fine)


### PR DESCRIPTION
For the homies that don't run the bridge then we don't need to load the compatibility events

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
If you don't have the bridge enabled trying to call the QBCore export will give you an error. This corrects that.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
