### PR TITLE
fix(callsign): callsign now actually sets

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -135,14 +135,14 @@ lib.addCommand('callsign', {
     help = Lang:t('commands.callsign'),
     params = {
         {
-            name = 'name',
+            name = 'callsign',
             type = 'string',
             help = Lang:t('info.callsign_name')
         }
     },
  }, function(source, args)
     local player = exports.qbx_core:GetPlayer(source)
-    player.Functions.SetMetaData('callsign', table.concat(args, ' '))
+    player.Functions.SetMetaData('callsign', args.callsign)
 end)
 
 lib.addCommand('clearcasings', {help = Lang:t('commands.clear_casign')}, function(source)


### PR DESCRIPTION
previous method wasnt actually setting the callsign - tested locally and works fine now

## Description

Fix callsign not setting.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
