### PR TITLE
feat: police plate with dynamic prefix in config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "cache",
         "QBX",
         "locale",
-        "qbx"
+        "qbx",
+        "MySQL"
     ]
 }

--- a/client/job.lua
+++ b/client/job.lua
@@ -103,8 +103,9 @@ local function takeOutVehicle(vehicleInfo)
     if not inGarage then return end
     local coords = sharedConfig.locations.vehicle[currentGarage]
     if not coords then return end
-
-    local plate = Lang:t('info.police_plate')..tostring(math.random(1000, 9999))
+    local pattern = ''
+    for _ = 8 - #sharedConfig.policePlatePrefix, #sharedConfig.policePlatePrefix do pattern = pattern..'1' end
+    local plate = sharedConfig.policePlatePrefix..lib.string.random(pattern):upper()
     local netId = lib.callback.await('qbx_policejob:server:spawnVehicle', false, vehicleInfo, coords, plate, true)
 
     local veh = lib.waitFor(function()
@@ -113,10 +114,8 @@ local function takeOutVehicle(vehicleInfo)
         end
     end)
 
-    if veh == 0 then
-        exports.qbx_core:Notify('Something went wrong spawning the vehicle', 'error')
-        return
-    end
+    assert(veh ~= 0, 'Something went wrong spawning the vehicle')
+
     setCarItemsInfo()
     SetEntityHeading(veh, coords.w)
     SetVehicleFuelLevel(veh, 100.0)

--- a/client/job.lua
+++ b/client/job.lua
@@ -104,7 +104,9 @@ local function takeOutVehicle(vehicleInfo)
     local coords = sharedConfig.locations.vehicle[currentGarage]
     if not coords then return end
     local pattern = ''
-    for _ = 8 - #sharedConfig.policePlatePrefix, #sharedConfig.policePlatePrefix do pattern = pattern..'1' end
+    for _ = 8 - #sharedConfig.policePlatePrefix, #sharedConfig.policePlatePrefix do
+        pattern = pattern..'1'
+    end
     local plate = sharedConfig.policePlatePrefix..lib.string.random(pattern):upper()
     local netId = lib.callback.await('qbx_policejob:server:spawnVehicle', false, vehicleInfo, coords, plate, true)
 

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -1,4 +1,5 @@
 return {
+    policePlatePrefix = 'LSPD',
     objects = {
         cone = {model = `prop_roadcone02a`, freeze = false},
         barrier = {model = `prop_barrier_work06a`, freeze = true},


### PR DESCRIPTION
## Description
Part of https://github.com/Qbox-project/qbx_policejob/pull/112

The plate prefix should be in the configuration not in locales.

Now the prefix “LSPD” can have a different number of characters.

## Checklist

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
