### PR TITLE
fix: updateBlips server function

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -20,8 +20,8 @@ end
 local function updateBlips()
     local dutyPlayers = {}
     local players = exports.qbx_core:GetQBPlayers()
-    for i = 1, #players do
-        local playerData = players[i].PlayerData
+    for _, player in pairs(players) do
+        local playerData = player.PlayerData
         local job = playerData.job
         if (job.type == 'leo' or job.type == 'ems') and job.onduty then
             local source = playerData.source


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Fixes the display of blips when the list of players contains empty indexes.

Check discord for more details.
https://discord.com/channels/1012753553418354748/1031968831595352085/1255760678451675186

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
